### PR TITLE
Switch to @react-native-community/async-storage.

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,9 +9,9 @@ import {
   Platform,
   Dimensions,
   ActivityIndicator,
-  AsyncStorage,
   FlatList
 } from "react-native";
+import AsyncStorage from '@react-native-community/async-storage'
 import emoji from "emoji-datasource";
 import "string.fromcodepoint";
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "author": "Arron Hunt",
   "license": "MIT",
   "dependencies": {
+    "@react-native-community/async-storage": "^1.7.1",
     "emoji-datasource": "^4.1.0",
     "prop-types": "^15.7.2",
     "string.fromcodepoint": "^0.2.1"


### PR DESCRIPTION
Importing AsyncStorage from react-native is deprecated. This is the replacement.

Please test this yourself before merging. I didn't test it because I don't know how to test a react native component in isolation.
